### PR TITLE
Centralized all calls to json.dumps in argonauts.dumps.

### DIFF
--- a/argonauts/__init__.py
+++ b/argonauts/__init__.py
@@ -6,6 +6,25 @@
 
 VERSION = (0, 9, 'alpha')
 
+
 def get_version():
     from . import version
     return version.to_string(VERSION)
+
+
+def dumps(*args, **kwargs):
+    """
+    Wrapper for json.dumps that uses the JSONArgonautsEncoder.
+    """
+    import json
+
+    from django.conf import settings
+    from argonauts.serializers import JSONArgonautsEncoder
+
+    kwargs.setdefault('cls', JSONArgonautsEncoder)
+    # pretty print in DEBUG mode.
+    if settings.DEBUG:
+        kwargs.setdefault('indent', 4)
+        kwargs.setdefault('separators', (',', ': '))
+
+    return json.dumps(*args, **kwargs)

--- a/argonauts/http.py
+++ b/argonauts/http.py
@@ -1,8 +1,6 @@
-import json
-
 from django.http import HttpResponseRedirect, HttpResponse
 
-from argonauts.serializers import JSONArgonautsEncoder
+from argonauts import dumps
 
 
 class HttpResponseSeeOther(HttpResponseRedirect):
@@ -20,8 +18,7 @@ class JsonResponse(HttpResponse):
             return JsonResponse({'foo': 1})
     """
 
-
     def __init__(self, context, *args, **kwargs):
-        content = json.dumps(context, cls=JSONArgonautsEncoder)
+        content = dumps(context)
         super(JsonResponse, self).__init__(content, *args, **kwargs)
         self['Content-Type'] = 'application/json'

--- a/argonauts/templatetags/argonauts.py
+++ b/argonauts/templatetags/argonauts.py
@@ -1,13 +1,9 @@
 from __future__ import absolute_import
 
-from json import dumps as json_dumps
-
 from django import template
-from django.conf import settings
-
 from django.utils.safestring import mark_safe
 
-from argonauts.serializers import JSONArgonautsEncoder
+from argonauts import dumps as json_dumps
 
 register = template.Library()
 
@@ -24,11 +20,7 @@ def json(a):
     If the output needs to be put in an attribute, entitize the output of this
     filter.
     """
-    kwargs = {}
-    if settings.DEBUG:
-        kwargs['indent'] = 4
-        kwargs['separators'] = (',', ': ')
-    json_str = json_dumps(a, cls=JSONArgonautsEncoder, **kwargs)
+    json_str = json_dumps(a)
 
     # Escape all the XML/HTML special characters.
     escapes = ['<', '>', '&']

--- a/argonauts/tests.py
+++ b/argonauts/tests.py
@@ -4,7 +4,7 @@ import decimal
 
 from django.utils import unittest
 
-from argonauts.serializers import JSONArgonautsEncoder
+from argonauts import dumps
 
 
 class TestObject(object):
@@ -17,7 +17,7 @@ class TestObject(object):
 
 class TestJson(unittest.TestCase):
     def encode_and_decode(self, v):
-        return json.loads(json.dumps(v, cls=JSONArgonautsEncoder))
+        return json.loads(dumps(v))
 
     def assertion(self, a, b):
         self.assertEqual(self.encode_and_decode(a), b)

--- a/argonauts/views.py
+++ b/argonauts/views.py
@@ -6,9 +6,8 @@ import json
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.http import HttpResponse, Http404
 from django.views.generic.base import View
-from django.conf import settings
 
-from argonauts.serializers import JSONArgonautsEncoder
+from argonauts import dumps
 
 
 class JsonResponseMixin(object):
@@ -30,11 +29,7 @@ class JsonResponseMixin(object):
         Returns a json serialized string object encoded using
         `argonauts.serializers.JSONArgonautsEncoder`.
         """
-        kwargs = {}
-        if settings.DEBUG:
-            kwargs['indent'] = 4
-            kwargs['separators'] = (',', ': ')
-        return json.dumps(obj, cls=JSONArgonautsEncoder, **kwargs)
+        return dumps(obj)
 
     def http_method_not_allowed(self, *args, **kwargs):
         """


### PR DESCRIPTION
Instead of doing this:

``` python
import json
from argonauts.serialize import JSONArgonautsEncoder

json.dumps(obj, cls=JSONArgonautsEncoder)
```

everywhere, do this

``` python
import argonauts

argonauts.dump(obj)
```
