### PR TITLE
Support lazy strings, like from ugettext_lazy

### DIFF
--- a/argonauts/serializers.py
+++ b/argonauts/serializers.py
@@ -1,5 +1,6 @@
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models.query import QuerySet
+from django.utils.functional import Promise
 
 
 class JSONArgonautsEncoder(DjangoJSONEncoder):
@@ -12,5 +13,14 @@ class JSONArgonautsEncoder(DjangoJSONEncoder):
 
         if isinstance(o, QuerySet):
             return list(o)
+
+        if isinstance(o, Promise) and hasattr(o, 'ljust'):
+            # Force lazy string evaluation to prevent errors:
+            # - not serializable as JSON without changes
+            # - circular reference when converting into text using six.u()
+            # While not clean, this seemed a safe method that does not assume
+            # whether it's text or binary.
+            # FIXME: find a cleaner solution and check if this is a Django bug
+            return o.ljust(0)
 
         return super(JSONArgonautsEncoder, self).default(o)

--- a/argonauts/tests.py
+++ b/argonauts/tests.py
@@ -1,6 +1,7 @@
 import json
 import datetime
 import decimal
+from django.utils.translation import ugettext_lazy, gettext_lazy
 
 try:
     from django.utils import unittest
@@ -43,6 +44,10 @@ class TestJson(unittest.TestCase):
         self.assertion(TestObject((TestObject('a'), TestObject('b'))), ['a', 'b'])
         self.assertion(decimal.Decimal('1.1'), '1.1')
         self.assertIn('2012-10-16', self.encode_and_decode(datetime.datetime(2012, 10, 16)))
+
+    def test_lazy_promise(self):
+        """There were issues with lazy string objects"""
+        self.assertion([ugettext_lazy(u'foo')], [u'foo'])
 
     def test_queryset(self):
         try:

--- a/argonauts/views.py
+++ b/argonauts/views.py
@@ -56,7 +56,7 @@ class JsonRequestMixin(object):
             return self.request.GET
         else:
             assert self.request.META['CONTENT_TYPE'].startswith('application/json')
-            return json.loads(self.request.body)
+            return json.loads(self.request.body.decode('utf-8'))
 
 
 class RestView(JsonResponseMixin, JsonRequestMixin, View):


### PR DESCRIPTION
The serializer crashed on lazy strings, like those returned by
ugettext_lazy(). The solution is not very clean, but I could not find a
better solution that works for both Python 2 and Python 3.