### PR TITLE
Set up the app registry when running tests on django 1.7

### DIFF
--- a/testproject/__init__.py
+++ b/testproject/__init__.py
@@ -3,10 +3,14 @@ import os
 import sys
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "testproject.testproject.settings")
 
+import django
 from django.test.utils import get_runner
 from django.conf import settings
 
 def runtests():
+    if hasattr(django, 'setup'):
+        # django >= 1.7
+        django.setup()
     # Stolen from django/core/management/commands/test.py
     TestRunner = get_runner(settings)
     test_runner = TestRunner(verbosity=1, interactive=True)


### PR DESCRIPTION
This fixes the `RuntimeError: App registry isn't ready yet.` errors.
