### PR TITLE
unicode escape single quote Fixes #17

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ to generate safe JavaScript:
     })();
   </script>
 
-``|json`` is safe to use anywhere in XML or XHTML except in an attribute. It's
+``|json`` is safe to use anywhere in XML or XHTML except in a double quoted attribute. It's
 important to use this tag rather than dumping the output of ``json.dumps`` into
 HTML, because an attacker could output a closing tag and effect an XSS attack.
 For example, if we output ``json.dumps("</script><script>console.log('xss');
@@ -60,7 +60,16 @@ escapes. If we output ``{{ somedata|json }}``, we get:
 .. code:: html
 
   <script>
-    var somedata = "\u0060xscript\u0062x\u0060xscript\u0062xconsole.log('xss');//";
+    var somedata = "\u0060xscript\u0062x\u0060xscript\u0062xconsole.log(\u0027xss\u0027);//";
+  </script>
+
+Argonauts also escapes single quotes this allows you to write valid JS for tools like
+eslint-plugin-html and for use in single quoted XML or XHTML attributes:
+
+.. code:: html
+
+  <script data-data='{{ extra|json }}'>
+    var somedata = JSON.parse('{{ somedata|json }}');
   </script>
 
 It also escapes ampersands in order to generate valid XML. For example, with the value

--- a/argonauts/templatetags/argonauts.py
+++ b/argonauts/templatetags/argonauts.py
@@ -23,7 +23,7 @@ def json(a):
     json_str = json_dumps(a)
 
     # Escape all the XML/HTML special characters.
-    escapes = ['<', '>', '&']
+    escapes = ['<', '>', '&', "'"]
     for c in escapes:
         json_str = json_str.replace(c, r'\u%04x' % ord(c))
 

--- a/test_argonauts.py
+++ b/test_argonauts.py
@@ -90,7 +90,7 @@ class TestJsonTemplateFilter(TestCase):
     def test_json_escapes_unsafe_characters(self):
         rendered = self.render_data("<script>alert('&XSS!');</script>")
 
-        self.assertEqual(rendered, '"\\u003cscript\\u003ealert(\'\\u0026XSS!\');\\u003c/script\\u003e"')
+        self.assertEqual(rendered, r'"\u003cscript\u003ealert(\u0027\u0026XSS!\u0027);\u003c/script\u003e"')
 
     @override_settings(DEBUG=True)
     def test_pretty_rendering_in_debug(self):


### PR DESCRIPTION
so I can do `var x = JSON.parse('{{ foo|json }}');`

This way I can run eslint and other code transformers over the code.